### PR TITLE
Fix deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "browserify": "^13.0.1",
     "budo": "^8.2.2",
     "surge": "^0.18.0",
-    "uglify-js": "^2.6.2"
+    "uglify-es": "^3"
   },
   "scripts": {
     "test": "node test.js",


### PR DESCRIPTION
One of the packages relies on a package, 'hex-rgb'. This package uses ES6 functionality, however uglify does not support ES6. I'd expect babelify to do something about this but... -shrugs-

Easiest fix that probably doesn't break anything; change the package from 'uglify-js' to 'uglify-es', which is made by the same author but supports ES6 expressions.